### PR TITLE
Corrected libfreenect.h location.

### DIFF
--- a/allonect/allonect/al_Freenect.hpp
+++ b/allonect/allonect/al_Freenect.hpp
@@ -44,7 +44,7 @@
 
 #include "allocore/al_Allocore.hpp"
 #include "alloutil/al_FPS.hpp"
-#include "libfreenect/libfreenect.h"
+#include "libfreenect.h"
 
 #include <map>
 


### PR DESCRIPTION
This is the location that the libfreenect-dev package uses on Lubuntu 13.04: http://packages.ubuntu.com/raring/all/libfreenect-dev/filelist .

And on Ubuntu 12.04:
http://packages.ubuntu.com/precise/all/libfreenect-dev/filelist .
