### PR TITLE
Fixed relative paths of asset loading examples.

### DIFF
--- a/allocore/examples/graphics/font.cpp
+++ b/allocore/examples/graphics/font.cpp
@@ -21,9 +21,9 @@ public:
 	Font font3;
 
 	MyApp()
-	:	font1("../../share/fonts/VeraMoIt.ttf", 20),
-		font2("../../share/fonts/VeraMoBd.ttf", 14),
-		font3("../../share/fonts/VeraMono.ttf", 10)
+	:	font1("allocore/share/fonts/VeraMoIt.ttf", 20),
+		font2("allocore/share/fonts/VeraMoBd.ttf", 14),
+		font3("allocore/share/fonts/VeraMono.ttf", 10)
 	{
 		nav().pos(0,0,4);
 		initWindow(Window::Dim(400,200));

--- a/allocore/examples/graphics/modelShader.cpp
+++ b/allocore/examples/graphics/modelShader.cpp
@@ -153,7 +153,7 @@ MyWindow win1;
 
 int main (int argc, char * const argv[]) {
 	searchpaths.addAppPaths(argc, argv);
-	searchpaths.addSearchPath(searchpaths.appPath() + "../../share");
+	searchpaths.addSearchPath(searchpaths.appPath() + "../../allocore/share");
 	searchpaths.print();
 	
 	// load in a "scene"

--- a/allocore/examples/graphics/textureImage.cpp
+++ b/allocore/examples/graphics/textureImage.cpp
@@ -24,7 +24,7 @@ struct MyApp : App {
 
     // Load a .jpg file
     //
-    const char *filename = "../../share/images/tiny.jpg";
+    const char *filename = "allocore/share/images/tiny.jpg";
 
     if (image.load(filename)) {
       printf("Read image from %s\n", filename);


### PR DESCRIPTION
Updated the paths in these examples to be relative to the root AlloSystem directory, which run.sh is required to be run from.

This suggests a possible update to run.sh: querying run.sh's absolute path and then using that as the basis for all other paths would allow the script it to be run from any pwd.
